### PR TITLE
Fixing link (protocol is always necessary)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # pitscher.github.io
-This is my personal blog in the making. If you want to find out more how to do to do it please visit my friend [kleinfreund](kleinfreund.de)
+This is my personal blog in the making. If you want to find out more how to do to do it please visit my friend [kleinfreund](http://hey.kleinfreund.de)
 
 
 ## To Do


### PR DESCRIPTION
Hey! When you link to something without a protocol (like `kleinfreund.de`), the link leads to `https://github.com/username/reponame/blob/master/kleinfreund.de`. Always include a protocol (http, https, etc.) for external ressources.

:)
